### PR TITLE
Update stuck.js

### DIFF
--- a/static/js/stuck.js
+++ b/static/js/stuck.js
@@ -69,7 +69,7 @@ var script = {
         ]
     },
     'USER_DOES_NOT_WANT_TO_SAVE_CHANGES': {
-        'question': 'OK! Type :qa !',
+        'question': 'OK! Type :qa!',
         'responses': [
             {
                 'text': 'Done!',


### PR DESCRIPTION
removed trailing white space changing `:qa !` to `:qa!`--the prior would error; `E488: Trailing Characters`.