### PR TITLE
Prevent horizonal scroll due to GitHub Banner

### DIFF
--- a/stuck.css
+++ b/stuck.css
@@ -1,5 +1,6 @@
 body {
     margin-top: 5em;
+    overflow-x: hidden;
 }
 
 /* https://stackoverflow.com/a/36151222/179729 */


### PR DESCRIPTION
The corner of the banner overflows on the right side, since the site is already pretty responsive, we can safely hide horizontal overflow on the body which then removes the scrollbar at the bottom of the site :)